### PR TITLE
Handle EVTX files with malformed event XML

### DIFF
--- a/Evtx/BinaryParser.py
+++ b/Evtx/BinaryParser.py
@@ -565,14 +565,13 @@ class Block(object):
         - `offset`: The relative offset from the start of the block.
         - `length`: The length of the string.
         Throws:
-        - `UnicodeDecodeError`
+        - N/A - function silently ignores characters that cannot
+                be unicode decoded.
         """
-        try:
-            return self._buf[self._offset + offset:self._offset + offset + \
-                             2 * length].tostring().decode("utf16")
-        except AttributeError: # already a 'str' ?
-            return self._buf[self._offset + offset:self._offset + offset + \
-                             2 * length].decode("utf16")
+        buf = self._buf[self._offset + offset:self._offset + offset + 2 * length]
+        if not isinstance(buf, str):
+            buf = buf.tostring()
+        return buf.decode('utf16', 'ignore')
 
     def unpack_dosdate(self, offset):
         """


### PR DESCRIPTION
EVTX files that contain events with malformed string data generate a
UnicodeDecode exception, which halts all parsing of an otherwise valid
EVTX file. This fix silently ignores characters that cannot be decoded
as UTF-16 which seems reasonable considering that the data is supposed
to be string data.  Note: there may be a more appropriate place to
handle this scenario in a calling function, however, this fix has the
advantage of returning as much data as possible to the caller (rather
than halting processing).