### PR TITLE
Fix infinite loop in ChunkHeader.records() when a record has length 0…

### DIFF
--- a/Evtx/BinaryParser.py
+++ b/Evtx/BinaryParser.py
@@ -186,7 +186,10 @@ def dosdate(dosdate, dostime):
 
 def parse_filetime(qword):
     # see http://integriography.wordpress.com/2010/01/16/using-phython-to-parse-and-present-windows-64-bit-timestamps/
-    return datetime.utcfromtimestamp(float(qword) * 1e-7 - 11644473600)
+    try:
+        return datetime.utcfromtimestamp(float(qword) * 1e-7 - 11644473600)
+    except ValueError:
+        return
 
 
 class BinaryParserException(Exception):

--- a/Evtx/BinaryParser.py
+++ b/Evtx/BinaryParser.py
@@ -189,7 +189,7 @@ def parse_filetime(qword):
     try:
         return datetime.utcfromtimestamp(float(qword) * 1e-7 - 11644473600)
     except ValueError:
-        return
+        return datetime.min
 
 
 class BinaryParserException(Exception):

--- a/Evtx/Evtx.py
+++ b/Evtx/Evtx.py
@@ -412,7 +412,7 @@ class ChunkHeader(Block):
 
     def records(self):
         record = self.first_record()
-        while record._offset < self._offset + self.next_record_offset():
+        while record._offset < self._offset + self.next_record_offset() and record.length() > 0:
             yield record
             try:
                 record = Record(self._buf,


### PR DESCRIPTION
…. Catch errors parsing filetimes.