### PR TITLE
Updated setup.py testing requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install lxml
       run: pip install lxml      
     - name: Install python-evtx
-      run: pip install -e .
+      run: pip install -e .[test]
     - name: Run tests
       run: pytest tests/
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
         install_requires=[
             'six',
             'hexdump==3.3',
-            'lxml==4.6.3',
                
             # pin deps for python 2, see #67
             'more_itertools==5.0.0',
@@ -37,6 +36,7 @@ setuptools.setup(
             "test": [
                 'pytest-cov==2.11.1',
                 'pytest==4.6.11',
+                'lxml==4.6.3',
             ]
         },
         scripts=['scripts/evtx_dump.py',

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,8 @@ setuptools.setup(
         packages=setuptools.find_packages(),
         install_requires=[
             'six',
-            'pytest==4.6.11',
             'hexdump==3.3',
-            'pytest-cov==2.11.1',
+
                
             # pin deps for python 2, see #67
             'more_itertools==5.0.0',
@@ -33,6 +32,13 @@ setuptools.setup(
             'configparser==4.0.2',
             'pyparsing==2.4.7',
             ],
+        extras_require={
+            # For running unit tests & coverage
+            "test": [
+                'pytest-cov==2.11.1',
+                'pytest==4.6.11',
+            ]
+        },
         scripts=['scripts/evtx_dump.py',
                  'scripts/evtx_dump_chunk_slack.py',
                  'scripts/evtx_eid_record_numbers.py',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         install_requires=[
             'six',
             'hexdump==3.3',
-
+            'lxml==4.6.3',
                
             # pin deps for python 2, see #67
             'more_itertools==5.0.0',


### PR DESCRIPTION
Thank you for this incredibly helpful project! I just wanted to contribute some tinkering to the setup.py file that limits the installation requirements for non-development usage. I also noticed that `lxml` was required to get unit tests passing, so I added it to that section as well. Let me know of any feedback!

I didn't update the README section on installation, though can to reflect if someone wants to run the unit tests, the would need to install the library with `pip install python-evtx[test]` to ensure pytest & lxml are included.