### PR TITLE
Fixed issue w/ Python 3

### DIFF
--- a/scripts/evtx_dump_chunk_slack.py
+++ b/scripts/evtx_dump_chunk_slack.py
@@ -40,7 +40,10 @@ def main():
                 last_allocated_offset = chunk_start
                 for record in chunk.records():
                     last_allocated_offset = record.offset() + record.size()
-                sys.stdout.write(buf[last_allocated_offset:chunk_start + 0x10000])
+                try:
+                    sys.stdout.buffer.write(buf[last_allocated_offset:chunk_start + 0x10000])
+                except:
+                      sys.stdout.write(buf[last_allocated_offset:chunk_start + 0x10000])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#74 Fixes the "write() argument must be str, not bytes" issue with Python 3 and maintains compatibility with Python 2.